### PR TITLE
Add DuckDB CI config and per-statement SQL execution

### DIFF
--- a/omicidx_etl/sql/010_raw_to_parquet.sql
+++ b/omicidx_etl/sql/010_raw_to_parquet.sql
@@ -75,10 +75,11 @@ copy (
 
 select count(*) from read_parquet('r2://omicidx/sra/parquet/sra_experiments.parquet');
 
+
+-- remove order by to reduce resource usage on github acions
 copy (
     select *
     from read_parquet('r2://omicidx/sra/raw/sample/**/*parquet')
-    order by accession
 ) to 'r2://omicidx/sra/parquet/sra_samples.parquet' (format parquet, compression zstd);
 
 

--- a/omicidx_etl/sql/runner.py
+++ b/omicidx_etl/sql/runner.py
@@ -51,7 +51,14 @@ create or replace secret r2 (
     ACCOUNT_ID '{aws_endpoint_url}'
 );"""
         con.execute(sql)
-    
+
+        # check if running in CI environment and adjust settings accordingly
+        if os.getenv('CI'):
+            logger.info("Running in CI environment, adjusting DuckDB settings for CI.")
+            con.execute("set memory_limit='4GB';")
+            con.execute("set threads=2;")
+            con.execute("set preserve_insertion_order=false;")
+        
         logger.info("sql secret for R2 created successfully.")
         return con
     except KeyError as e:


### PR DESCRIPTION
## Summary
- Adds CI-specific DuckDB settings (`memory_limit=4GB`, `threads=2`, `preserve_insertion_order=false`) when running on GitHub Actions
- Splits SQL file execution into individual statements using sqlglot, with per-statement logging for visibility into which operation is running or stuck

## Context
The Daily SQL Runner workflow has been failing on GitHub Actions, likely due to memory/disk pressure from large DuckDB operations. These changes:
1. Constrain DuckDB resource usage in CI to leave headroom for the OS
2. Allow DuckDB to release resources between statements rather than executing entire SQL files as a single operation
3. Make it easy to identify which specific SQL statement is the bottleneck

## Test plan
- [ ] Trigger `Daily SQL Runner` workflow on this branch to verify it completes
- [ ] Check logs for per-statement progress output

🤖 Generated with [Claude Code](https://claude.com/claude-code)