### PR TITLE
Move SQL runner to local systemd timer with GH Actions status reporting

### DIFF
--- a/.github/workflows/sql_runner.yaml
+++ b/.github/workflows/sql_runner.yaml
@@ -1,9 +1,9 @@
 name: Daily SQL Runner
+# NOTE: Daily runs now happen via systemd timer on the local server.
+# See deploy/sql-runner/ for the systemd setup.
+# This workflow is kept for occasional manual runs from GitHub Actions.
 on:
   workflow_dispatch:
-  schedule:
-    # Run daily at 7am UTC
-    - cron:  '0 7 * * *'
 
 jobs:
   run-sql:

--- a/.github/workflows/sql_runner_status.yaml
+++ b/.github/workflows/sql_runner_status.yaml
@@ -1,0 +1,44 @@
+name: SQL Runner Status
+
+on:
+  workflow_dispatch:
+    inputs:
+      status:
+        description: 'Run status (success or failure)'
+        required: true
+        type: string
+      duration:
+        description: 'Run duration'
+        required: true
+        type: string
+      timestamp:
+        description: 'Run start timestamp (UTC)'
+        required: true
+        type: string
+      details:
+        description: 'Additional details'
+        required: false
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report SQL Runner Status
+        run: |
+          echo "## SQL Runner Status Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ inputs.status }}" = "success" ]; then
+            echo "**Status:** :white_check_mark: Success" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Status:** :x: Failure" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "**Started:** ${{ inputs.timestamp }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Duration:** ${{ inputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ inputs.details }}" ]; then
+            echo "**Details:** ${{ inputs.details }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail if SQL runner failed
+        if: ${{ inputs.status != 'success' }}
+        run: exit 1

--- a/deploy/sql-runner/README.md
+++ b/deploy/sql-runner/README.md
@@ -1,0 +1,75 @@
+# SQL Runner - systemd Deployment
+
+The Daily SQL Runner runs on the local Rocky Linux server via systemd, replacing the GitHub Actions scheduled workflow. A lightweight GH Actions workflow receives status reports for public visibility.
+
+## Prerequisites
+
+- `uv` installed and on PATH
+- `gh` CLI installed and authenticated (needs `workflow` scope)
+- This repo cloned to `/home/davsean/Documents/git/omicidx-etl`
+
+## Setup
+
+1. Create the config directory and environment file:
+
+```bash
+mkdir -p ~/.config/omicidx
+cp deploy/sql-runner/env.example ~/.config/omicidx/env
+# Edit ~/.config/omicidx/env and fill in all values
+chmod 600 ~/.config/omicidx/env
+```
+
+2. Make the wrapper script executable:
+
+```bash
+chmod +x deploy/sql-runner/run-and-report.sh
+```
+
+3. Install the systemd units (user-level):
+
+```bash
+mkdir -p ~/.config/systemd/user
+ln -sf "$(pwd)/deploy/sql-runner/omicidx-sql-runner.service" ~/.config/systemd/user/
+ln -sf "$(pwd)/deploy/sql-runner/omicidx-sql-runner.timer" ~/.config/systemd/user/
+systemctl --user daemon-reload
+```
+
+4. Enable and start the timer:
+
+```bash
+systemctl --user enable --now omicidx-sql-runner.timer
+```
+
+5. Enable lingering so user services run without an active login session:
+
+```bash
+sudo loginctl enable-linger davsean
+```
+
+## Usage
+
+Check timer status:
+
+```bash
+systemctl --user status omicidx-sql-runner.timer
+systemctl --user list-timers
+```
+
+Trigger a manual run:
+
+```bash
+systemctl --user start omicidx-sql-runner
+```
+
+View logs:
+
+```bash
+journalctl --user -u omicidx-sql-runner
+journalctl --user -u omicidx-sql-runner -f  # follow
+```
+
+Check last run result:
+
+```bash
+systemctl --user status omicidx-sql-runner.service
+```

--- a/deploy/sql-runner/env.example
+++ b/deploy/sql-runner/env.example
@@ -1,0 +1,16 @@
+# AWS / R2 credentials
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=auto
+AWS_ENDPOINT_URL=
+AWS_URL_STYLE=path
+
+# OmicIDX settings
+OMICIDX_BASE_PATH=
+
+# GitHub CLI token (needs workflow dispatch permissions)
+GH_TOKEN=
+
+# Python settings
+PYTHONUNBUFFERED=1
+LOGURU_LEVEL=DEBUG

--- a/deploy/sql-runner/omicidx-sql-runner.service
+++ b/deploy/sql-runner/omicidx-sql-runner.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OmicIDX Daily SQL Runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=davsean
+WorkingDirectory=/home/davsean/Documents/git/omicidx-etl
+EnvironmentFile=/home/davsean/.config/omicidx/env
+ExecStart=/home/davsean/Documents/git/omicidx-etl/deploy/sql-runner/run-and-report.sh
+TimeoutStartSec=18000
+
+[Install]
+WantedBy=default.target

--- a/deploy/sql-runner/omicidx-sql-runner.timer
+++ b/deploy/sql-runner/omicidx-sql-runner.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=OmicIDX Daily SQL Runner Timer
+
+[Timer]
+OnCalendar=*-*-* 07:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/sql-runner/run-and-report.sh
+++ b/deploy/sql-runner/run-and-report.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="omicidx/omicidx-etl"
+WORKFLOW="sql_runner_status.yaml"
+
+start_time=$(date +%s)
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Run the SQL job
+exit_code=0
+uv run oidx sql run || exit_code=$?
+
+end_time=$(date +%s)
+duration=$(( end_time - start_time ))
+
+# Determine status
+if [ "$exit_code" -eq 0 ]; then
+    status="success"
+else
+    status="failure"
+fi
+
+# Report status to GitHub Actions
+gh workflow run "$WORKFLOW" \
+    --repo "$REPO" \
+    -f status="$status" \
+    -f duration="${duration}s" \
+    -f timestamp="$timestamp" \
+    -f details="Exit code: $exit_code" \
+    || echo "Warning: failed to report status to GitHub Actions"
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary

- Adds systemd service + timer units to run the daily SQL job on the local Rocky Linux server at 07:00 UTC
- Adds a `run-and-report.sh` wrapper that captures exit code/duration and reports status back to GitHub via `gh workflow run`
- Adds a lightweight `sql_runner_status.yaml` workflow (dispatch-only) that displays the reported status in the GH Actions UI
- Removes the `schedule` cron trigger from the existing `sql_runner.yaml` (keeps `workflow_dispatch` for manual runs)

## Test plan

- [ ] On the Rocky Linux server: pull this branch, copy `env.example` to `~/.config/omicidx/env`, fill in secrets
- [ ] Symlink systemd units, `systemctl --user daemon-reload`
- [ ] `systemctl --user start omicidx-sql-runner` for a manual test run
- [ ] Verify logs via `journalctl --user -u omicidx-sql-runner`
- [ ] Confirm the `SQL Runner Status` workflow was triggered on GitHub
- [ ] Enable the timer: `systemctl --user enable --now omicidx-sql-runner.timer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)