### PR TITLE
Handle XML parse errors gracefully in SRA extraction

### DIFF
--- a/omicidx_etl/sra/catalog.py
+++ b/omicidx_etl/sra/catalog.py
@@ -225,18 +225,29 @@ class SRACatalog:
             log_every=1,  # Log every entry since there are typically few
         )
         
+        failures = []
         for entry in current_batch:
             try:
                 self.process_one(entry)
                 progress.update()
             except Exception as e:
+                failures.append(entry.entity)
                 self.log.error(
-                    "Failed to process entry",
+                    "Failed to process entry — continuing with remaining entities",
                     url=entry.url,
                     entity=entry.entity,
                     error=str(e),
                     exc_info=True,
                 )
-                raise
-        
+
         progress.complete()
+
+        if failures:
+            self.log.error(
+                "Batch completed with failures",
+                failed_entities=failures,
+                total=len(current_batch),
+            )
+            raise RuntimeError(
+                f"Failed to process {len(failures)} entries: {', '.join(failures)}"
+            )

--- a/omicidx_etl/sra/mirror_parquet.py
+++ b/omicidx_etl/sra/mirror_parquet.py
@@ -10,6 +10,7 @@ import gzip
 import shutil
 import tempfile
 from typing import Callable, Iterable, Optional
+from xml.etree.ElementTree import ParseError
 
 from loguru import logger
 from upath import UPath
@@ -108,13 +109,22 @@ def process_mirror_entry_to_parquet_parts(
 
     logger.info(f"Processing {url}", entity=entity, chunk_size=CHUNK_SIZE)
 
-    for rec in iter_sra_record_dicts_from_mirror_url(url):
-        if normalize_fn is not None:
-            rec = normalize_fn(rec, schema)
-        buf.append(rec)
+    try:
+        for rec in iter_sra_record_dicts_from_mirror_url(url):
+            if normalize_fn is not None:
+                rec = normalize_fn(rec, schema)
+            buf.append(rec)
 
-        if len(buf) >= CHUNK_SIZE:
-            flush()
+            if len(buf) >= CHUNK_SIZE:
+                flush()
+    except ParseError as e:
+        logger.error(
+            f"XML parse error in {url}: {e}. "
+            f"Flushing {len(buf)} buffered records. "
+            f"Already wrote {len(written)} parts."
+        )
+        flush()
+        raise
 
     flush()
     return written


### PR DESCRIPTION
## Summary

- **mirror_parquet.py**: Catch `ParseError` during XML streaming, flush buffered records to parquet before re-raising. This preserves partial data (potentially millions of records) instead of discarding them.
- **catalog.py**: Continue processing remaining entity types when one fails. A corrupt `sample` file no longer prevents `run`, `experiment`, and `study` from completing. Failures are reported at the end so CI still marks the job as failed.

Fixes #11

## Context

The SRA extraction job failed on 2026-03-01 after ~2 hours because NCBI's `meta_sample_set.xml.gz` had a mismatched XML tag at line 2.3 billion. Previously, this crashed the entire job and lost all in-memory buffered data. With this fix:

1. Buffered records are flushed to parquet before the error propagates
2. Other entity types continue processing
3. No done marker is written for the failed entity, so the next run retries it
4. The job still exits non-zero so CI reports the failure

## Test plan

- [x] `oidx sra extract --entity sample --since 2026-03-02` completes successfully (incremental file)
- [x] `oidx sra extract --dry-run` shows all 8 entries correctly
- [x] Code imports without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)