### PR TITLE
Auto-cleanup old SRA data after extraction

### DIFF
--- a/omicidx_etl/sra/catalog.py
+++ b/omicidx_etl/sra/catalog.py
@@ -117,16 +117,29 @@ class SRACatalog:
             except Exception:
                 pass
     
-    def cleanup(self, mirror_entries: List[SRAMirrorEntry]) -> None:
+    def get_completed_entities(self, mirror_entries: List[SRAMirrorEntry]) -> set[str]:
+        """Return entity names whose current-batch Full entry has a done marker."""
+        completed = set()
+        for entry in mirror_entries:
+            if entry.in_current_batch and entry.is_full:
+                if self._done_marker_path(entry).exists():
+                    completed.add(entry.entity)
+        return completed
+
+    def cleanup(self, mirror_entries: List[SRAMirrorEntry], completed_entities: set[str] | None = None) -> None:
         """
         Clean up the catalog by removing old files.
-        
-        Only removes entries that are not in the current batch.
-        
+
+        Only removes entries that are not in the current batch. If completed_entities
+        is provided, only removes entries whose entity is in that set (safety filter).
+
         Args:
             mirror_entries: List of all mirror entries
+            completed_entities: If provided, only clean up entities in this set
         """
         to_cleanup = [e for e in mirror_entries if not e.in_current_batch]
+        if completed_entities is not None:
+            to_cleanup = [e for e in to_cleanup if e.entity in completed_entities]
         
         self.log.info(
             "Starting cleanup",

--- a/omicidx_etl/sra/cli.py
+++ b/omicidx_etl/sra/cli.py
@@ -51,6 +51,11 @@ def sra():
     default=None,
     help="Limit number of entries to process (useful for testing)",
 )
+@click.option(
+    "--cleanup/--no-cleanup",
+    default=True,
+    help="Clean up old entries after processing (default: on)",
+)
 def extract(
     output_base: Optional[str],
     since: Optional[date],
@@ -58,6 +63,7 @@ def extract(
     entity: str,
     dry_run: bool,
     max_entries: Optional[int],
+    cleanup: bool,
 ):
     """
     Extract SRA metadata from NCBI mirror to parquet format.
@@ -139,10 +145,34 @@ def extract(
         catalog = SRACatalog(dest)
 
         log.info("Processing entries")
-        catalog.process(filtered_entries)
-        
+        process_error = None
+        try:
+            catalog.process(filtered_entries)
+        except RuntimeError as e:
+            # Partial failure — some entities succeeded, some failed.
+            # Continue to cleanup for the ones that succeeded.
+            process_error = e
+            log.warning("Processing had partial failures, continuing to cleanup", error=str(e))
+
+        # Auto-cleanup: remove old data only for entities that completed successfully
+        if cleanup:
+            completed = catalog.get_completed_entities(filtered_entries)
+            if completed:
+                log.info("Running auto-cleanup for completed entities", entities=sorted(completed))
+                catalog.cleanup(filtered_entries, completed_entities=completed)
+            else:
+                log.info("No entities completed successfully, skipping cleanup")
+        else:
+            log.info("Cleanup disabled via --no-cleanup")
+
+        if process_error:
+            raise process_error
+
         log.info("SRA sync completed successfully")
-        
+
+    except RuntimeError:
+        # Already logged above — re-raise without double-logging
+        raise
     except Exception as e:
         log.error("SRA sync failed", error=str(e), exc_info=True)
         raise


### PR DESCRIPTION
## Summary

- Add safe auto-cleanup to `oidx sra extract` so old SRA entries are removed after processing, preventing duplicate records in downstream SQL consolidation
- Only cleans up entities whose current-batch Full entry completed successfully (done marker exists) — failed entities keep their old data as the only copy
- Add `--cleanup/--no-cleanup` flag (default: on) for opt-out control

## Test plan

- [ ] `uv run oidx sra extract --dry-run` — verify current batch listing still works
- [ ] `uv run oidx sra extract --entity study` — confirm extraction + auto-cleanup runs
- [ ] `uv run oidx sra extract --no-cleanup` — confirm cleanup is skipped
- [ ] `uv run oidx sra cleanup --dry-run` — standalone cleanup still works unchanged

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)